### PR TITLE
grid_view: Reduce density to 5

### DIFF
--- a/furios_gallery/grid_view.py
+++ b/furios_gallery/grid_view.py
@@ -68,8 +68,8 @@ class GridView(Adw.NavigationPage):
         self.flowbox.set_valign(Gtk.Align.START)
         self.flowbox.set_column_spacing(0)
         self.flowbox.set_row_spacing(0)
-        self.flowbox.set_max_children_per_line(6)
-        self.flowbox.set_min_children_per_line(6)
+        self.flowbox.set_max_children_per_line(5)
+        self.flowbox.set_min_children_per_line(5)
         self.flowbox.set_selection_mode(Gtk.SelectionMode.SINGLE)
         self.flowbox.set_homogeneous(True)
 
@@ -119,7 +119,7 @@ class GridView(Adw.NavigationPage):
         if thumbnail_path:
             flowbox_child = Gtk.FlowBoxChild()
             flowbox_child.media_index = media_index
-            flowbox_child.set_size_request(50, 70)
+            flowbox_child.set_size_request(50, 90)
 
             GLib.idle_add(
                 self.thumbnails.update_ui_with_thumbnail,


### PR DESCRIPTION
Slightly reduce the grid density from 6 images per row to 5 and increase the height so its easier to see what each image is

This is a subjective change

Before: 
![Screenshot from 2025-01-24 16-45-03](https://github.com/user-attachments/assets/5a3515fd-2b4a-4ef6-bf10-6284d3bc9b2e)

After:
![Screenshot from 2025-01-24 16-44-32](https://github.com/user-attachments/assets/91f51a08-9d8f-4e3b-a93c-fd991ce77ea2)
