### PR TITLE
Combine check_file_integrity and remove unnecessary calls

### DIFF
--- a/furios_gallery/media_manager.py
+++ b/furios_gallery/media_manager.py
@@ -135,46 +135,44 @@ def populate_database(conn):
 
     print(f"Processed {len(media_items)} media files.")
 
-def check_picture_integrity(file_path):
+def check_file_integrity(file_path):
     if not os.path.exists(file_path):
-        print(file_path)
+        print(f"File does not exist: {file_path}")
         return False
 
     if os.path.getsize(file_path) == 0:
-        print(file_path)
+        print(f"File is empty: {file_path}")
         return False
 
     try:
-        with Image.open(file_path) as img:
-            img.verify()
+        if extract_extension(file_path) in PICTURE_EXTENSIONS:
+            with Image.open(file_path) as img:
+                img.verify()
 
-            img = Image.open(file_path)
-            img.getpixel((0, 0))
+                img = Image.open(file_path)
+                img.getpixel((0, 0))
+
+                return True
+        elif extract_extension(file_path) in VIDEO_EXTENSIONS:
+            command = [
+                "ffmpeg",
+                "-i", file_path,
+                "-f",
+                "null",
+                "-"
+            ]
+            subprocess.run(command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
             return True
+        else:
+            return None
+
     except (IOError, ValueError) as e:
-        print(f"Image could not be opened or is corrupted: {str(e)}")
+        print(f"File could not be opened or is corrupted: {str(e)}")
         return False
     except Exception as e:
         print(f"An unexpected error occurred: {str(e)}")
         return False
-
-def check_video_integrity(file_path):
-    # TBD: Do not use subprocess, no bueno, and we need to do smt about .mkv
-    try:
-        result = subprocess.run(
-            ['ffmpeg', '-v', 'error', '-i', file_path, '-f', 'null', '-'],
-            stderr=subprocess.PIPE,
-            text=True
-        )
-    except Exception as e:
-        print(f"An error occurred while checking {file_path}: {e}")
-        return False
-
-def check_file_integrity(file_path):
-    if extract_extension(file_path) in PICTURE_EXTENSIONS:
-        return check_picture_integrity(file_path)
-    elif extract_extension(file_path) in VIDEO_EXTENSIONS:
-        return check_video_integrity(file_path)
 
 def insert_file(conn, file_path, file_type):
     cur = conn.cursor()

--- a/furios_gallery/thumbnail_utils.py
+++ b/furios_gallery/thumbnail_utils.py
@@ -19,9 +19,9 @@ def generate_image_thumbnail(image_path):
     base_name = os.path.splitext(os.path.basename(image_path))[0]
     thumbnail_path = os.path.join(CACHE_DIR, f"{base_name}_thumbnail.jpg")
     if not os.path.exists(thumbnail_path):
-        if not os.path.exists(image_path) or os.path.getsize(image_path) == 0:
-            print(f"File does not exist or is empty: {image_path}")
+        if not check_file_integrity(image_path):
             return None
+
         try:
             with Image.open(image_path) as img:
                 img.thumbnail(THUMBNAIL_SIZE)
@@ -39,24 +39,27 @@ def generate_image_thumbnail(image_path):
 def generate_video_thumbnail(video_path):
     base_name = os.path.splitext(os.path.basename(video_path))[0]
     thumbnail_path = os.path.join(CACHE_DIR, f"{base_name}_thumbnail.jpg")
-    if os.path.exists(thumbnail_path):
-        return thumbnail_path
-    try:
-        command = [
-            "ffmpeg",
-            "-i", video_path,
-            "-ss", "00:00:01",
-            "-vframes", "1",
-            "-q:v", "2",
-            thumbnail_path
-        ]
-        subprocess.run(command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        with Image.open(thumbnail_path) as img:
-            img.thumbnail(THUMBNAIL_SIZE)
-            img.save(thumbnail_path, format="JPEG")
-    except subprocess.CalledProcessError as e:
-        print(f"ffmpeg error: {e}")
-        return None
+    if not os.path.exists(thumbnail_path):
+        if not check_file_integrity(video_path):
+            return None
+
+        try:
+            command = [
+                "ffmpeg",
+                "-i", video_path,
+                "-ss", "00:00:01",
+                "-vframes", "1",
+                "-q:v", "2",
+                thumbnail_path
+            ]
+            subprocess.run(command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            with Image.open(thumbnail_path) as img:
+                img.thumbnail(THUMBNAIL_SIZE)
+                img.save(thumbnail_path, format="JPEG")
+        except subprocess.CalledProcessError as e:
+            print(f"ffmpeg error: {e}")
+            return None
+        
     return thumbnail_path
 
 def has_thumbnail(media_path):
@@ -64,13 +67,10 @@ def has_thumbnail(media_path):
     return os.path.exists(thumbnail_path)
 
 def generate_thumbnail(media_path):
-    if check_file_integrity(media_path):
-        media_path = os.path.abspath(media_path)
-        if extract_extension(media_path) in PICTURE_EXTENSIONS:
-            return generate_image_thumbnail(media_path)
-        elif extract_extension(media_path) in VIDEO_EXTENSIONS:
-            return generate_video_thumbnail(media_path)
-        else:
-            return None
+    media_path = os.path.abspath(media_path)
+    if extract_extension(media_path) in PICTURE_EXTENSIONS:
+        return generate_image_thumbnail(media_path)
+    elif extract_extension(media_path) in VIDEO_EXTENSIONS:
+        return generate_video_thumbnail(media_path)
     else:
         return None


### PR DESCRIPTION
Combines the two image and video functions together to have a more consistent experience as this makes sure all the checks are happening like file size and existing for both images and videos

Removes the check_file_integrity call in the thumbnail generator if the thumbnail already exists so we do constantly check all files on every single launch which inflates the launch time if lots of videos.