### PR TITLE
grid_view: Remove extra file integrity check

### DIFF
--- a/furios_gallery/grid_view.py
+++ b/furios_gallery/grid_view.py
@@ -115,21 +115,20 @@ class GridView(Adw.NavigationPage):
         self.app.current_index = end_index
 
     def add_media_to_flowbox(self, media_path, media_index):
-        if check_file_integrity(media_path):
-            thumbnail_path = self.thumbnails.generate_thumbnail(media_path)
+        thumbnail_path = self.thumbnails.generate_thumbnail(media_path)
 
-            if thumbnail_path:
-                flowbox_child = Gtk.FlowBoxChild()
-                flowbox_child.media_index = media_index
-                flowbox_child.set_size_request(50, 90)
+        if thumbnail_path:
+            flowbox_child = Gtk.FlowBoxChild()
+            flowbox_child.media_index = media_index
+            flowbox_child.set_size_request(50, 90)
 
-                GLib.idle_add(
-                    self.thumbnails.update_ui_with_thumbnail,
-                    flowbox_child,
-                    thumbnail_path
-                )
+            GLib.idle_add(
+                self.thumbnails.update_ui_with_thumbnail,
+                flowbox_child,
+                thumbnail_path
+            )
 
-                GLib.idle_add(self.flowbox.append, flowbox_child)
+            GLib.idle_add(self.flowbox.append, flowbox_child)
 
     def on_child_selected(self, flowbox):
         if self.flowbox.get_selection_mode() == Gtk.SelectionMode.SINGLE:


### PR DESCRIPTION
Removes extra file integrity check as it shouldn't be needed due to it being checked in the generate_thumbnail function causing the file to be checked twice

That duplicate check was causing it to slowly load in the thumbnails and causing a skipped invalid index spam.