### PR TITLE
media_manager: Remove getpixel check

### DIFF
--- a/furios_gallery/media_manager.py
+++ b/furios_gallery/media_manager.py
@@ -149,9 +149,6 @@ def check_file_integrity(file_path):
             with Image.open(file_path) as img:
                 img.verify()
 
-                img = Image.open(file_path)
-                img.getpixel((0, 0))
-
                 return True
         elif ext in VIDEO_EXTENSIONS:
             with av.open(file_path) as container:


### PR DESCRIPTION
Removes the getpixel check in the check_file_integrity as it will still return a value even if the image is empty thus it doesn't work in preventing empty images from being added