### PR TITLE
Add flatpak

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,32 @@
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - trixie
+
+name: CI
+jobs:
+  flatpak:
+    name: "Flatpak"
+    runs-on: ${{ matrix.os }}
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-47
+      options: --privileged
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            os: ubuntu-24.04
+
+          - arch: aarch64
+            os: ubuntu-24.04-arm
+      # Don't fail the whole workflow if one architecture fails
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v4
+    - uses: flathub-infra/flatpak-github-actions/flatpak-builder@master
+      with:
+        bundle: io.FuriOS.Gallery.flatpak
+        manifest-path: io.FuriOS.Gallery.yml
+        cache-key: flatpak-builder-${{ github.sha }}
+        arch: ${{ matrix.arch }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 **/__pycache__/
+build-dir
+.flatpak-builder
+repo
+*.flatpak

--- a/io.FuriOS.Gallery.yml
+++ b/io.FuriOS.Gallery.yml
@@ -1,0 +1,132 @@
+app-id: io.FuriOS.Gallery
+runtime: org.gnome.Platform
+runtime-version: '47'
+sdk: org.gnome.Sdk
+sdk-extensions: [
+  'org.freedesktop.Sdk.Extension.rust-stable'
+]
+command: io.FuriOS.Gallery
+build-options:
+  append-path: '/usr/lib/sdk/rust-stable/bin'
+
+finish-args:
+  - --device=all
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/app/lib64/gstreamer-1.0
+  - --env=GST_PLUGIN_PATH=/app/lib/gstreamer-1.0:/app/lib64/gstreamer-1.0
+  - --env=GI_TYPELIB_PATH=/app/lib/girepository-1.0
+  - --env=LD_LIBRARY_PATH=/app/lib:/app/lib64
+  - --env=PYTHONPATH=/app/lib/python3.10/site-packages
+  - --talk-name=io.FuriOS.Gallery
+  # Store database
+  - --filesystem=xdg-data
+  # Store thumbnails
+  - --filesystem=xdg-cache
+  # Access media
+  - --filesystem=xdg-videos
+  - --filesystem=xdg-pictures
+
+cleanup: [
+  '/include',
+  '/lib/pkgconfig',
+  '/man',
+  '/share/doc',
+  '/share/gtk-doc',
+  '/share/man',
+  '/share/pkgconfig',
+  '*.la',
+  '*.a'
+]
+
+modules:
+  - name: libprotobuf-c
+    buildsystem: autotools
+    config-opts:
+      - --disable-protoc
+    sources:
+      - type: archive
+        url: https://github.com/protobuf-c/protobuf-c/releases/download/v1.5.0/protobuf-c-1.5.0.tar.gz
+        sha256: 7b404c63361ed35b3667aec75cc37b54298d56dd2bcf369de3373212cc06fd98
+
+  - name: shumate
+    buildsystem: meson
+    config-opts:
+      - -Dgtk_doc=false
+    sources:
+      - type: git
+        url: https://gitlab.gnome.org/GNOME/libshumate
+        tag: 1.3.2
+        commit: a0a175f5b6e2a6708a2980b7304168007ac6bfbb
+
+  - name: gstreamer
+    buildsystem: meson
+    build-options:
+      build-args:
+        - --share=network
+    config-opts:
+      - --buildtype=release
+      - --libdir=lib
+      - --prefix=/app
+
+      # Disable unneeded items to speedup build
+      - -Dgst-examples=disabled
+      - -Dqt5=disabled
+      - -Dexamples=disabled
+      - -Dtests=disabled
+      - -Ddoc=disabled
+      - -Dgtk_doc=disabled
+      - -Dintrospection=disabled
+
+      # Enable the plugins
+      - -Dbase=enabled
+      - -Dgood=enabled
+      - -Dbad=enabled
+      - -Dugly=disabled
+      - -Drs=enabled
+      - -Dvaapi=enabled
+    sources:
+      - type: git
+        url: https://gitlab.freedesktop.org/gstreamer/gstreamer
+        tag: 1.24.12
+        commit: 88e31216479a3f0c25096ca406369f3983efec14
+        disable-submodules: true
+    cleanup: [
+      '/include',
+      '/lib/*.la',
+      '/lib/gstreamer-1.0/*.la',
+      '/lib/gstreamer-1.0/include',
+      '/lib/pkgconfig',
+      '/share/gtk-doc'
+    ]   
+
+  - name: furios-gallery
+    buildsystem: simple
+    build-options:
+      build-args:
+        - --share=network
+    build-commands:
+      # Install Python files
+      - mkdir -p /app/lib/furios-gallery
+      - cp -r furios_gallery /app/lib/furios-gallery/
+      - cp main.py /app/lib/furios-gallery/
+
+      # Install desktop file
+      - mkdir -p /app/share/applications
+      - cp data/io.FuriOS.Gallery.desktop /app/share/applications/
+
+      # Install icon
+      - mkdir -p /app/share/icons/hicolor/scalable/apps
+      - cp data/io.FuriOS.Gallery.svg /app/share/icons/hicolor/scalable/apps/
+
+       # Create symbolic links for binaries
+      - mkdir -p /app/bin
+      - ln -s /app/lib/furios-gallery/main.py /app/bin/io.FuriOS.Gallery
+
+      # Install Python dependencies
+      - pip install --prefix=/app -r requirements.txt
+    sources:
+      - type: dir
+        path: .

--- a/io.FuriOS.Gallery.yml
+++ b/io.FuriOS.Gallery.yml
@@ -116,12 +116,14 @@ modules:
       # Install desktop file
       - mkdir -p /app/share/applications
       - cp data/io.FuriOS.Gallery.desktop /app/share/applications/
+      # Change desktop name with the FuriLabs prefix per FuriLabs request
+      - sed -i -e 's/Name=/Name=FuriLabs /g' /app/share/applications/io.FuriOS.Gallery.desktop
 
       # Install icon
       - mkdir -p /app/share/icons/hicolor/scalable/apps
       - cp data/io.FuriOS.Gallery.svg /app/share/icons/hicolor/scalable/apps/
 
-       # Create symbolic links for binaries
+      # Create symbolic links for binaries
       - mkdir -p /app/bin
       - ln -s /app/lib/furios-gallery/main.py /app/bin/io.FuriOS.Gallery
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+av
+PyGObject
+pyinotify
+pillow


### PR DESCRIPTION
This adds a flatpak manifest along with a github action that will build it so it can be downloaded from the action right now. We might want to take a look at creating github releases and having the runner upload it as a release artifact so it easier to download since you need to be logged in to github to download from a action directly. For now it only runs on pushes to trixie so it should only build when new changes are merged in to the main branch, we can take a look to see if we want it to run on PR too that way people can test new PR easier.

This will not handle uploading to flathub as that is something im not familiar with but should probably be something we take a look at once we think this is ready for non FLX1 users.

You can see what a run looks like here
https://github.com/luigi311/furios-gallery/actions/runs/13096124319

Added a sed command to prefix the flatpak desktop name with FuriLabs per Barry's request