### PR TITLE
Add AppStream Metainfo

### DIFF
--- a/io.FuriOS.Gallery.metainfo.xml
+++ b/io.FuriOS.Gallery.metainfo.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" ?>
+<component type="desktop-application">
+  <id>io.FuriOS.Gallery</id>
+  <name>FuriOS Gallery</name>
+  <summary>View your Photos and Videos</summary>
+  <description>
+    <p>Media gallery application for FuriOS</p>
+  </description>
+  <project_license>GPL-2.0-only</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <url type="homepage">https://github.com/FuriLabs/furios-gallery</url>
+  <url type="bugtracker">https://github.com/FuriLabs/furios-gallery/issues</url>
+  <url type="vcs-browser">https://github.com/FuriLabs/furios-gallery</url>
+  <launchable type="desktop-id">io.FuriOS.Gallery.desktop</launchable>
+  <categories>
+    <category>GTK</category>
+    <category>GNOME</category>
+    <category>Graphics</category>
+    <category>Viewer</category>
+  </categories>
+  <developer>
+    <name>FuriOS Gallery Team</name>
+    <url>https://github.com/FuriLabs/furios-gallery/blob/trixie/gallery_daemon.py#L6-L9</url>
+  </developer>
+  <recommends>
+    <display_length compare="ge">360</display_length>
+  </recommends>
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </supports>
+  <releases>
+    <release version="1.0.0" date="2025-01-28">
+      <description translate="no">
+        <ul>
+          <li>Initial release</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+</component>


### PR DESCRIPTION
Hi,

thanks for creating this nice app!

In order to make maintenance for LinuxPhoneApps.org less painful for me, here's a contribution to the metainfo of the project:

It's likely not perfect metadata yet (at least per flathub's suggestions on https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines ), but it's good enough for my purposes. If submitting the app to flathub is a goal, please note the [app id requirements](https://docs.flathub.org/docs/for-app-authors/requirements/#application-id):

> The domain portion must be in lowercase and must convert dash - to underscore _ and also prefix any intial digits with an underscore _.

which is also the reason why I have named this file io.furios.… instead of io.FuriOS.… .

Also, I've set the homepage to the repo - if this is okay, a README.md would be a great addition, otherwise, linking to https://furilabs.com/gallery-app/ would be an alternative.

If you want to add more, here's some reading material:

- https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html
- https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html

One thing that would be nice to have specified is whether the app requires internet access: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-relations-internet.

Feel free to suggest changes before merging :-)